### PR TITLE
Fix ux edge cases

### DIFF
--- a/client/src/pages/BattlePage.jsx
+++ b/client/src/pages/BattlePage.jsx
@@ -26,6 +26,7 @@ function BattlePage({ matchDetails }) {
   const [resultDialogTitle, setResultDialogTitle] = useState("");
   const [resultDialogMessage, setResultDialogMessage] = useState("");
   const [resultDialogElo, setResultDialogElo] = useState(null);
+  const [showExitButton, setShowExitButton] = useState(false);
   const editorRef = useRef(null);
 
   const handleEditorDidMount = (editor) => {
@@ -78,6 +79,7 @@ function BattlePage({ matchDetails }) {
                 setResultDialogMessage(res.data.message);
                 setResultDialogElo(res.data.ratingDifference);
                 setResultDialogOpen(true);
+                setShowExitButton(true);
                 return; // Exit polling on success
               }
               else {
@@ -149,7 +151,7 @@ function BattlePage({ matchDetails }) {
             <span className="font-bold text-2xl">{matchDetails.players[1]}</span>
           </div>
         </div>
-        <Button onClick={handleExit} className="bg-slate-950 text-white px-4 py-2 rounded-md"> Exit Match</Button>
+        <Button onClick={handleExit} className={showExitButton ? "" : "hidden " + `bg-slate-950 text-white px-4 py-2 rounded-md`}> Exit Match</Button>
       </div>
       {/* Split screen */}
       <ResizablePanelGroup direction="horizontal" className="flex-1 flex flex-col md:flex-row gap-4 p-4 overflow-auto">

--- a/server/helpers/redisMatchMaking.js
+++ b/server/helpers/redisMatchMaking.js
@@ -82,10 +82,10 @@ async function createMatch(player1Id, player2Id) {
   await redis.expire(`${MATCH_DATA_PREFIX}${matchId}`, (45 * 60) + 10); // 45 minutes + 10 seconds
   // Allow each player to lookup their match
   await redis.set(`${PLAYER_MATCH_PREFIX}${player1Id}`, matchId);
-  await redis.expire(`${PLAYER_MATCH_PREFIX}${player1Id}`, (45 * 60) + 10); // 45 minutes + 10 seconds
+  await redis.expire(`${PLAYER_MATCH_PREFIX}${player1Id}`, 10); 
 
   await redis.set(`${PLAYER_MATCH_PREFIX}${player2Id}`, matchId);
-  await redis.expire(`${PLAYER_MATCH_PREFIX}${player2Id}`, (45 * 60) + 10); // 45 minutes + 10 seconds
+  await redis.expire(`${PLAYER_MATCH_PREFIX}${player2Id}`, 10); 
 
   console.log(`✅ Match Created: ${matchId} between ${player1Id} and ${player2Id}`);
 }


### PR DESCRIPTION
This pull request introduces changes to improve the user experience on the `BattlePage` by conditionally displaying the "Exit Match" button and modifies match expiration logic in the backend to reduce the expiration time for player-specific match lookups.

### Frontend Changes: Conditional Display of "Exit Match" Button
* [`client/src/pages/BattlePage.jsx`](diffhunk://#diff-4819dbed15ead0df7f034cc34ca09fd21871adbebd30a5db3badf162d85701b4R29): Added a new state variable `showExitButton` to control the visibility of the "Exit Match" button.
* [`client/src/pages/BattlePage.jsx`](diffhunk://#diff-4819dbed15ead0df7f034cc34ca09fd21871adbebd30a5db3badf162d85701b4R82): Updated the logic to set `showExitButton` to `true` when the match result dialog is displayed.
* [`client/src/pages/BattlePage.jsx`](diffhunk://#diff-4819dbed15ead0df7f034cc34ca09fd21871adbebd30a5db3badf162d85701b4L152-R154): Modified the "Exit Match" button to use the `showExitButton` state for conditional rendering, hiding it until the match is concluded.

### Backend Changes: Match Expiration Logic
* [`server/helpers/redisMatchMaking.js`](diffhunk://#diff-f1e9bf93a7dcdee9e5c9f1909f916b142c2bce50db637fabe7a40c8d4aeaa0d8L85-R88): Reduced the expiration time for player-specific match lookups from 45 minutes to 10 seconds to prevent entering previous match even after exiting.