### PR TITLE
Heatmap addition

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,6 +26,7 @@
         "lucide-react": "^0.511.0",
         "next-themes": "^0.4.6",
         "react": "^19.1.0",
+        "react-calendar-heatmap": "^1.10.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
@@ -4466,7 +4467,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4877,6 +4877,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5067,6 +5079,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -5726,7 +5744,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6038,6 +6055,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -6129,6 +6157,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-calendar-heatmap": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-calendar-heatmap/-/react-calendar-heatmap-1.10.0.tgz",
+      "integrity": "sha512-e5vcrzMWzKIF710egr1FpjWyuDEFeZm39nvV25muc8Wtqqi8iDOfqREELeQ9Wouqf9hhj939gq0i+iAxo7KdSw==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -6149,6 +6190,12 @@
       "peerDependencies": {
         "react": "*"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "lucide-react": "^0.511.0",
     "next-themes": "^0.4.6",
     "react": "^19.1.0",
+    "react-calendar-heatmap": "^1.10.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",

--- a/client/src/components/Heatmap.jsx
+++ b/client/src/components/Heatmap.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import CalendarHeatmap from "react-calendar-heatmap";
+import "react-calendar-heatmap/dist/styles.css";
+
+const today = new Date();
+
+function shiftDate(date, numDays) {
+  const newDate = new Date(date);
+  newDate.setDate(newDate.getDate() + numDays);
+  return newDate;
+}
+
+function getRange(count) {
+  return Array.from({ length: count }, (_, i) => i);
+}
+
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export default function Heatmap({ values, startDate, endDate }) {
+  // If no values provided, generate random demo data
+  const randomValues = values || getRange(200).map(index => ({
+    date: shiftDate(today, -index),
+    count: getRandomInt(0, 5),
+  }));
+  const start = startDate || shiftDate(today, -150);
+  const end = endDate || today;
+  return (
+    <div>
+      <CalendarHeatmap
+        startDate={start}
+        endDate={end}
+        values={randomValues}
+        classForValue={value => {
+          if (!value || value.count === 0) {
+            return "color-fuchsia-0";
+          }
+          if (value.count >= 8) return "color-fuchsia-5";
+          if (value.count >= 5) return "color-fuchsia-4";
+          if (value.count >= 3) return "color-fuchsia-3";
+          if (value.count >= 2) return "color-fuchsia-2";
+          return "color-fuchsia-1";
+        }}
+        tooltipDataAttrs={value => {
+          if (!value || !value.date) return null;
+          return {
+            'data-tooltip': value.count
+              ? `${value.count} matches on ${value.date instanceof Date ? value.date.toISOString().slice(0, 10) : value.date}`
+              : `No matches on ${value.date instanceof Date ? value.date.toISOString().slice(0, 10) : value.date}`,
+          };
+        }}
+        showWeekdayLabels={true}
+        onClick={value => value && alert(`Clicked on value with count: ${value.count}`)}
+      />
+    </div>
+  );
+}

--- a/client/src/components/Heatmap.jsx
+++ b/client/src/components/Heatmap.jsx
@@ -3,6 +3,8 @@ import CalendarHeatmap from "react-calendar-heatmap";
 import "react-calendar-heatmap/dist/styles.css";
 
 const today = new Date();
+const startOfYear = new Date(today.getFullYear(), 0, 1);
+const endOfYear = new Date(today.getFullYear(), 11, 31);
 
 function shiftDate(date, numDays) {
   const newDate = new Date(date);
@@ -18,24 +20,48 @@ function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-export default function Heatmap({ values, startDate, endDate }) {
-  // If no values provided, generate random demo data
-  const randomValues = values || getRange(200).map(index => ({
-    date: shiftDate(today, -index),
-    count: getRandomInt(0, 5),
-  }));
-  const start = startDate || shiftDate(today, -150);
-  const end = endDate || today;
+// Generate mock data for every day in the year
+function generateYearMockData() {
+  const daysInYear = Math.ceil((endOfYear - startOfYear) / (1000 * 60 * 60 * 24)) + 1;
+  return getRange(daysInYear).map(index => {
+    const date = shiftDate(startOfYear, index);
+    return {
+      date: date.toISOString().slice(0, 10),
+      count: getRandomInt(0, 5),
+    };
+  });
+}
+
+// ---
+// BACKEND INTEGRATION TIPS:
+// 1. The backend should provide an array of objects for the current year, where each object is:
+//    { date: 'YYYY-MM-DD', count: <number of matches played on that day> }
+// 2. The frontend expects this array as the 'values' prop for CalendarHeatmap.
+// 3. The color intensity is determined by the 'count' field (see classForValue below).
+// 4. If a day is missing from the array, it will be treated as 0 matches (color-fuchsia-0).
+// 5. To integrate, replace 'generateYearMockData()' with a prop or API call that fetches the real data for the logged-in user.
+// 6. Example API response:
+//    [ { date: '2025-01-01', count: 2 }, { date: '2025-01-02', count: 0 }, ... ]
+// 7. The backend should ensure all days in the year are present, or the frontend should fill missing days with count: 0.
+// ---
+
+export default function Heatmap({ data }) {
+  // If 'data' is not provided, fallback to mock data for development
+  const yearMockData = data || generateYearMockData();
   return (
-    <div>
+    <div style={{ width: "100%", maxWidth: 1100, margin: "0 auto", fontFamily: 'inherit', color: '#fff', background: 'transparent', overflow: 'hidden' }}>
       <CalendarHeatmap
-        startDate={start}
-        endDate={end}
-        values={randomValues}
+        startDate={startOfYear}
+        endDate={endOfYear}
+        values={yearMockData}
         classForValue={value => {
+          const todayStr = new Date().toISOString().slice(0, 10);
           if (!value || value.count === 0) {
+            // Future days
+            if (value && value.date > todayStr) return "color-fuchsia-future";
             return "color-fuchsia-0";
           }
+          if (value.date > todayStr) return "color-fuchsia-future";
           if (value.count >= 8) return "color-fuchsia-5";
           if (value.count >= 5) return "color-fuchsia-4";
           if (value.count >= 3) return "color-fuchsia-3";
@@ -44,13 +70,25 @@ export default function Heatmap({ values, startDate, endDate }) {
         }}
         tooltipDataAttrs={value => {
           if (!value || !value.date) return null;
+          const todayStr = new Date().toISOString().slice(0, 10);
+          if (value.date > todayStr) {
+            return {
+              'data-tooltip': `Day yet to come (${value.date})`,
+            };
+          }
+          if (value.count) {
+            return {
+              'data-tooltip': `${value.count} matches on ${value.date}`,
+            };
+          }
           return {
-            'data-tooltip': value.count
-              ? `${value.count} matches on ${value.date instanceof Date ? value.date.toISOString().slice(0, 10) : value.date}`
-              : `No matches on ${value.date instanceof Date ? value.date.toISOString().slice(0, 10) : value.date}`,
+            'data-tooltip': `No matches on ${value.date}`,
           };
         }}
         showWeekdayLabels={true}
+        horizontal={true}
+        gutterSize={2}
+        squareSize={13}
         onClick={value => value && alert(`Clicked on value with count: ${value.count}`)}
       />
     </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -119,3 +119,27 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Fuchsia color scale for heatmap */
+.react-calendar-heatmap .color-fuchsia-0 {
+  fill: #fdf4ff;
+}
+.react-calendar-heatmap .color-fuchsia-1 {
+  fill: #f5d0fe;
+}
+.react-calendar-heatmap .color-fuchsia-2 {
+  fill: #e879f9;
+}
+.react-calendar-heatmap .color-fuchsia-3 {
+  fill: #c026d3;
+}
+.react-calendar-heatmap .color-fuchsia-4 {
+  fill: #a21caf;
+}
+.react-calendar-heatmap .color-fuchsia-5 {
+  fill: #701a75;
+}
+.react-calendar-heatmap rect:hover {
+  stroke: #f472b6;
+  stroke-width: 1.5px;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -118,6 +118,9 @@
   body {
     @apply bg-background text-foreground;
   }
+  body, #root, .dashboard-bg {
+    background: #101010 !important;
+  }
 }
 
 /* Fuchsia color scale for heatmap */
@@ -139,7 +142,20 @@
 .react-calendar-heatmap .color-fuchsia-5 {
   fill: #701a75;
 }
+.react-calendar-heatmap .color-fuchsia-future {
+  fill: #44444a;
+}
 .react-calendar-heatmap rect:hover {
   stroke: #f472b6;
   stroke-width: 1.5px;
+}
+.react-calendar-heatmap rect {
+  rx: 0;
+  ry: 0;
+}
+.react-calendar-heatmap text {
+  fill: #fff !important;
+}
+.react-calendar-heatmap {
+  background: transparent !important;
 }

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,14 +1,19 @@
 import React from "react";
 import { RevealBento } from "../components/Bento";
+import Heatmap from "../components/Heatmap";
+import "../index.css";
 
 export default function Dashboard() {
   return (
     <div className="min-h-screen bg-[#101010] text-white">
       {/* Main Dashboard Content */}
-      <main className="p-6 flex flex-col justify-center min-h-[80vh]">
-        <RevealBento />
-        <div className="absolute bottom-82 left-0 right-0 flex">
+      <main className="p-6 flex flex-col justify-center min-h-[80vh] gap-0">
+        <RevealBento className="pb-0 mb-0" />
+        {/* Restrict Heatmap width for original sizing, no extra margin */}
+        <div className="w-full max-w-3xl ml-80 mt-[-264px]">
+          <Heatmap />
         </div>
+        <div className="absolute bottom-82 left-0 right-0 flex"></div>
       </main>
     </div>
   );

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -9,8 +9,8 @@ export default function Dashboard() {
       {/* Main Dashboard Content */}
       <main className="p-6 flex flex-col justify-center min-h-[80vh] gap-0">
         <RevealBento className="pb-0 mb-0" />
-        {/* Restrict Heatmap width for original sizing, no extra margin */}
-        <div className="w-full max-w-3xl ml-80 mt-[-264px]">
+        {/* Restrict Heatmap width for original sizing, add more margin-top for gap */}
+        <div className="w-full max-w-3xl mx-auto mt-[-264px]">
           <Heatmap />
         </div>
         <div className="absolute bottom-82 left-0 right-0 flex"></div>


### PR DESCRIPTION
Heatmap calendar to the dashboard to visually represent a user's daily match activity throughout the year.

How the color scheme works:

    Each square on the calendar represents a day.

    The color intensity increases based on the number of matches played on that day. The more matches, the darker the shade, using a fuchsia-themed scale.

    Future dates are shown in gray, so it's easy to tell which days haven't occurred yet.

Tooltip behavior:

    For future dates, it shows: "Day yet to come (YYYY-MM-DD)"

    If there were no matches: "No matches on YYYY-MM-DD"

    If matches were played: "X matches on YYYY-MM-DD"