### PR TITLE
Fix path issue in loadTestCases.js

### DIFF
--- a/server/helpers/loadTestCases.js
+++ b/server/helpers/loadTestCases.js
@@ -1,10 +1,15 @@
 import fs from 'fs'
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 dotenv.config();
 
 export function loadTestCases(problemSlug) {
-  const dir = `${process.env.PATH_TO_PROBLEMS}/${problemSlug}/testcases`;
+  const dir = path.join(__dirname, '..', 'problems', problemSlug, 'testcases');
   const inputs = fs.readdirSync(`${dir}/inputs`);
 
   return inputs.map((file) => {


### PR DESCRIPTION
This pull request updates the `loadTestCases` helper function to improve path handling and ensure compatibility with ES modules. The changes replace hardcoded paths with dynamic path resolution using `path` and `fileURLToPath`.

Path handling improvements:

* [`server/helpers/loadTestCases.js`](diffhunk://#diff-d5d2190de74b0e734b7a35629b8d5a671689011c69e2d7e89eadd9b7cfd24f4fR3-R12): Added `path` and `fileURLToPath` imports, defined `__filename` and `__dirname` for ES module compatibility, and updated the `dir` variable to use `path.join` for constructing paths dynamically.